### PR TITLE
Ensure empty CROSS_COMPILE is set when native.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-05-26  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	* build-libs.sh: Set CROSS_PREFIX as CROSS_COMPILE value for make.
+
 2014-05-23  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	* .gitignore: Created.

--- a/build-libs.sh
+++ b/build-libs.sh
@@ -142,7 +142,7 @@ case $(uname -p) in
 		;;
 esac
 
-MAKE="make $CROSS_PREFIX " 
+MAKE="make CROSS_COMPILE=$CROSS_PREFIX " 
 CLEAN=
 
 while [[ $# > 0 ]]; do


### PR DESCRIPTION
```
* build-libs.sh: Set CROSS_PREFIX as CROSS_COMPILE value for make.
```
