### PR TITLE
e-hal: Force reset of shm_table if it is corrupted

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2014-10-14 Ola Jeppsson <ola@adapteva.com>
+	* src/e-hal/src/epiphany-shm-manager.c:
+	Force reset of shm table if it is corrupted, instead of failing.
+
+2014-10-14 Ola Jeppsson <ola@adapteva.com>
 	* src/e-hal/Makefile:
 	Link with -lpthreads. e-shm API uses POSIX semaphores.
 


### PR DESCRIPTION
Force reset of shm_table on init if we detect that it is corrupted.
Since .shared_dram==shm_table with current and previous linker scripts all
programs that puts data in the shared_dram section will corrupt the table.
