### PR TITLE
Use "'const char*' executable" for e_load

### DIFF
--- a/src/e-loader/src/e-loader.c
+++ b/src/e-loader/src/e-loader.c
@@ -35,8 +35,8 @@
 
 #define diag(vN)   if (e_load_verbose >= vN)
 
-e_return_stat_t ee_process_ELF(char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col);
-e_return_stat_t ee_process_SREC(char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col);
+e_return_stat_t ee_process_ELF(const char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col);
+e_return_stat_t ee_process_SREC(const char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col);
 int ee_set_core_config(e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col);
 
 e_loader_diag_t e_load_verbose = 0;
@@ -47,7 +47,7 @@ FILE *diag_fd = NULL;
 // TODO: replace with platform data
 #define EMEM_SIZE (0x02000000)
 
-int e_load(char *executable, e_epiphany_t *dev, unsigned row, unsigned col, e_bool_t start)
+int e_load(const char *executable, e_epiphany_t *dev, unsigned row, unsigned col, e_bool_t start)
 {
 	int status;
 
@@ -57,7 +57,7 @@ int e_load(char *executable, e_epiphany_t *dev, unsigned row, unsigned col, e_bo
 }
 
 
-int e_load_group(char *executable, e_epiphany_t *dev, unsigned row, unsigned col, unsigned rows, unsigned cols, e_bool_t start)
+int e_load_group(const char *executable, e_epiphany_t *dev, unsigned row, unsigned col, unsigned rows, unsigned cols, e_bool_t start)
 {
 	e_mem_t      emem, *pemem;
 	unsigned int irow, icol;

--- a/src/e-loader/src/e-loader.h
+++ b/src/e-loader/src/e-loader.h
@@ -41,8 +41,8 @@ typedef enum {
 	L_D4 = 40,
 } e_loader_diag_t;
 
-int e_load(char *executable, e_epiphany_t *dev, unsigned row, unsigned col, e_bool_t start);
-int e_load_group(char *executable, e_epiphany_t *dev, unsigned row, unsigned col, unsigned rows, unsigned cols, e_bool_t start);
+int e_load(const char *executable, e_epiphany_t *dev, unsigned row, unsigned col, e_bool_t start);
+int e_load_group(const char *executable, e_epiphany_t *dev, unsigned row, unsigned col, unsigned rows, unsigned cols, e_bool_t start);
 
 e_loader_diag_t e_set_loader_verbosity(e_loader_diag_t verbose);
 

--- a/src/e-loader/src/e-process-SREC.c
+++ b/src/e-loader/src/e-process-SREC.c
@@ -52,7 +52,7 @@ extern int e_load_verbose;
 extern FILE *diag_fd;
 
 
-e_return_stat_t ee_process_ELF(char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col)
+e_return_stat_t ee_process_ELF(const char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col)
 {
 	FILE       *elfStream;
 	Elf32_Ehdr hdr;
@@ -130,7 +130,7 @@ e_return_stat_t ee_process_ELF(char *executable, e_epiphany_t *pEpiphany, e_mem_
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-e_return_stat_t ee_process_SREC(char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col)
+e_return_stat_t ee_process_SREC(const char *executable, e_epiphany_t *pEpiphany, e_mem_t *pEMEM, int row, int col)
 {
 	typedef enum {S0, S3, S7} SrecSel;
 	FILE      *srecStream;


### PR DESCRIPTION
e_load(_group) should treat srec filename as **const** char* .

Non-constant char* causes some compilation error/warning with C++ because string literal is "const char[]" type.

Do you have any reason to user non-constant char* ?