### PR TITLE
enable src in shared memory read

### DIFF
--- a/src/e-lib/src/e_mem_read.c
+++ b/src/e-lib/src/e_mem_read.c
@@ -36,7 +36,7 @@ void *e_read(const void *remote, void *dst, unsigned row, unsigned col, const vo
 	} else if (*((e_objtype_t *) remote) == E_SHARED_MEM) {
 		// src is ignored for shared memory reads
 		e_memseg_t *pmem = (e_memseg_t *)remote;
-		gsrc = (void*)pmem->ephy_base;
+		gsrc = (void *) (pmem->ephy_base + (unsigned) src);
 	} else {
 		gsrc = (void *) (e_emem_config.base + (unsigned) src);
 	}

--- a/src/e-lib/src/e_mem_read.c
+++ b/src/e-lib/src/e_mem_read.c
@@ -34,7 +34,6 @@ void *e_read(const void *remote, void *dst, unsigned row, unsigned col, const vo
 	if (*((e_objtype_t *) remote) == E_EPI_GROUP) {
 		gsrc = e_get_global_address(row, col, src);
 	} else if (*((e_objtype_t *) remote) == E_SHARED_MEM) {
-		// src is ignored for shared memory reads
 		e_memseg_t *pmem = (e_memseg_t *)remote;
 		gsrc = (void *) (pmem->ephy_base + (unsigned) src);
 	} else {

--- a/src/e-lib/src/e_mem_write.c
+++ b/src/e-lib/src/e_mem_write.c
@@ -36,7 +36,7 @@ void *e_write(const void *remote, const void *src, unsigned row, unsigned col, v
 	} else if (*((e_objtype_t *) remote) == E_SHARED_MEM) {
 		// dst is ignored for shared memory writes
 		e_memseg_t *pmem = (e_memseg_t *)remote;
-		gdst = (void*)pmem->ephy_base;
+		gdst = (void*) (pmem->ephy_base + (unsigned) dst);
 	} else {
 		gdst = (void *) (e_emem_config.base + (unsigned) dst);
 	}

--- a/src/e-lib/src/e_mem_write.c
+++ b/src/e-lib/src/e_mem_write.c
@@ -34,7 +34,6 @@ void *e_write(const void *remote, const void *src, unsigned row, unsigned col, v
 	if (*((e_objtype_t *) remote) == E_EPI_GROUP) {
 		gdst = e_get_global_address(row, col, dst);
 	} else if (*((e_objtype_t *) remote) == E_SHARED_MEM) {
-		// dst is ignored for shared memory writes
 		e_memseg_t *pmem = (e_memseg_t *)remote;
 		gdst = (void*) (pmem->ephy_base + (unsigned) dst);
 	} else {


### PR DESCRIPTION
I wish to have src enabled in memory read for shared memory. It seems to be disabled by purpose, if there is reason for that please explain it to me :)